### PR TITLE
Ajout de CORS

### DIFF
--- a/campus_zen_backend/settings.py
+++ b/campus_zen_backend/settings.py
@@ -37,11 +37,13 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'rest_framework', 
+    'rest_framework',
+    'corsheaders',
     'campusZen',
 ]
 
 MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -52,6 +54,9 @@ MIDDLEWARE = [
 ]
 
 ROOT_URLCONF = 'campus_zen_backend.urls'
+
+# Pour le développement (accepte toutes les origines)
+CORS_ALLOW_ALL_ORIGINS = True
 
 TEMPLATES = [
     {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,44 +1,11 @@
-# Core Django
-Django==4.2.7
-djangorestframework==3.14.0
-
-# Database
-psycopg2-binary==2.9.7
-
-# CORS (pour autoriser les requêtes depuis React Native)
-django-cors-headers==4.3.1
-
-# Authentication & Security
-djangorestframework-simplejwt==5.3.0
-django-allauth==0.57.0
-
-# Configuration & Environment
-python-decouple==3.8
-django-environ==0.11.2
-
-# Media & Files
-Pillow==10.0.1
-django-storages==1.14.2
-
-# Development & Debug
-django-debug-toolbar==4.2.0
-django-extensions==3.2.3
-
-# API Documentation
-drf-spectacular==0.26.5
-
-# Validation & Utilities
-django-filter==23.3
-python-slugify==8.0.1
-
-# Date & Time
-python-dateutil==2.8.2
-
-# Testing
-pytest==7.4.3
-pytest-django==4.7.0
-factory-boy==3.3.0
-
-# Production (optionnel)
-gunicorn==21.2.0
-whitenoise==6.6.0
+asgiref==3.9.1
+beautifulsoup4==4.13.5
+Django==4.2.24
+django-bootstrap-v5==1.0.11
+django-cors-headers==4.9.0
+django-debug-toolbar==6.0.0
+django-rest-framework==0.1.0
+djangorestframework==3.16.1
+soupsieve==2.8
+sqlparse==0.5.3
+typing_extensions==4.15.0


### PR DESCRIPTION
Cette pull request met à jour le backend Django pour activer la prise en charge du partage de ressources entre origines multiples (CORS), ce qui est important pour permettre aux applications frontend hébergées sur différentes origines d'interagir avec le backend pendant le développement.

**Prise en charge CORS :**
* Ajout du package `corsheaders` à la liste `INSTALLED_APPS` dans `settings.py`, activant la fonctionnalité CORS dans le projet Django.
* Ajout de `corsheaders.middleware.CorsMiddleware` à la liste `MIDDLEWARE` pour traiter les en-têtes CORS sur les requêtes entrantes.
* Définition de `CORS_ALLOW_ALL_ORIGINS = True` dans `settings.py` pour autoriser les requêtes depuis n'importe quelle origine, simplifiant le développement et les tests.

---

**Note importante :** `CORS_ALLOW_ALL_ORIGINS = True` est pratique pour le développement, mais **ne doit jamais être utilisé en production** pour des raisons de sécurité. En production, il faut spécifier uniquement les origines autorisées avec `CORS_ALLOWED_ORIGINS`.