### PR TITLE
test de la liaison avec le site railraw.app

### DIFF
--- a/campus_zen_backend/settings.py
+++ b/campus_zen_backend/settings.py
@@ -25,7 +25,8 @@ SECRET_KEY = 'django-insecure-lcpljd52dld)6=2v^=7#*95nsl9j12m^df@=fph5#ddxo9_op$
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['*']  # Autorise tous les hôtes 
+
 
 
 # Application definition


### PR DESCRIPTION
This pull request makes a minor configuration change to the Django settings file to allow the application to accept requests from any host. This is achieved by setting `ALLOWED_HOSTS` to `['*']`.

- Set `ALLOWED_HOSTS` to `['*']` in `campus_zen_backend/settings.py`, allowing the application to accept requests from any host.